### PR TITLE
fix ignoring parameter -a

### DIFF
--- a/lib/thin_service/command.rb
+++ b/lib/thin_service/command.rb
@@ -219,7 +219,7 @@ module ThinService
           # now the options
           argv << "-e #{@environment}" if @environment
           argv << "-p #{@port}"
-          argv << "-a #{@host}"  if @host
+          argv << "-a #{@address}"  if @address
           argv << "-c \"#{@cwd}\"" if @cwd
           argv << "-t #{@timeout}" if @timeout
           argv << "-D" if @debug


### PR DESCRIPTION
After command:
thin_service install -N ServiceName -p 3000 -a any.local
Service always started at 0.0.0.0 but not "any.local"
